### PR TITLE
refactor-created partial render for user profile page

### DIFF
--- a/app/views/users/_profile.html.erb
+++ b/app/views/users/_profile.html.erb
@@ -1,0 +1,36 @@
+<div class="container-fluid d-flex justify-content-center align-items-center flex-column">
+  <div class="container mb-3">
+    <div class="row">
+      <div class="col-lg-3 mx-auto ">
+        <h1><%= @user.username.capitalize %>'s Profile</h1>
+        <div class="card" style="max-width: 15rem;">
+          <% if @user.avatar_image.present? %>
+            <div class="card-body d-flex justify-content-center">
+              <%= image_tag @user.avatar_image, class: "card-img-top" %>
+            </div>
+          <% end %>
+          <div class="card-body p-3">
+            <p class="card-text">Member since: <%= @user.created_at.strftime("%B %d, %Y") %></p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="container mb-3">
+
+    <div class="col-lg-6 mx-auto">
+      <ul class="nav nav-tabs mt-4 justify-content-center">
+        <li class="nav-item">
+          <%= link_to "Pending", user_path(@user.username), class: "nav-link" %>
+        </li>
+        <li class="nav-item">
+          <%= link_to "Completed", completed_path(@user.username), class: "nav-link" %>
+        </li>
+        <li class="nav-item">
+          <%= link_to "Failed", failed_path(@user.username), class: "nav-link" %>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/app/views/users/completed.html.erb
+++ b/app/views/users/completed.html.erb
@@ -1,62 +1,31 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<div class="container-fluid d-flex justify-content-center align-items-center flex-column">
-  <div class="container mb-3">
-    <div class="row">
-      <div class="col-lg-3 mx-auto">
-        <h1><%= @user.username.capitalize %>'s Profile</h1>
-        <div class="card" style="max-width: 15rem;">
-          <% if @user.avatar_image.present? %>
-            <div class="card-body d-flex justify-content-center">
-              <%= image_tag @user.avatar_image, class: "card-img-top" %>
-            </div>
-          <% end %>
-          <div class="card-body p-3">
-            <p class="card-text">Member since: <%= @user.created_at.strftime("%B %d, %Y") %></p>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
 
-  <div class="container mb-3">
-    <div class="col-lg-6 mx-auto">
-      <ul class="nav nav-tabs mt-4 justify-content-center">
-        <li class="nav-item">
-          <%= link_to "Pending", user_path(@user.username), class: "nav-link" %>
-        </li>
-        <li class="nav-item">
-          <%= link_to "Completed", completed_path(@user.username), class: "nav-link" %>
-        </li>
-        <li class="nav-item">
-          <%= link_to "Failed", failed_path(@user.username), class: "nav-link" %>
-        </li>
-      </ul>
-      <div class="d-flex justify-content-center mb-3">
-        <h3><%= @user.username.capitalize %>'s Completed Tasks</h3>
-      </div>
-      <% @user.own_tasks.each do |task| %>
-        <% if task.status == "completed" %>
-          <%= render "tasks/task", task: task %>
-        <% end %>
-      <% end %>
-    </div>
-  </div>
+<%= render "profile" %>
 
-  <br>
-
-  <div class="container mb-3">
-    <div class="row">
-      <div class="col">
-        <div class="d-flex justify-content-center mb-3">
-          <h2><%= @user.username.capitalize %>'s Pets</h2>
-        </div>
-        <div class="row row-cols-1 row-cols-md-2 g-4">
-          <% @user.own_pets.each do |pet| %>
-            <%= render "pets/pet", pet: pet %>
-          <% end %>
-        </div>
-      </div>
-    </div>
-  </div>
+<div class="d-flex justify-content-center mb-3">
+  <h3><%= @user.username.capitalize %>'s Completed Tasks</h3>
 </div>
+<div class = "container mb-3">
+  <% @user.own_tasks.each do |task| %>
+    <% if task.status == "completed" %>
+      <%= render "tasks/task", task: task %>
+    <% end %>
+  <% end %>
+</div>
+
+<br>
+
+<div class="container mb-3">
+  <div class="row">
+    <div class="col">
+      <div class="d-flex justify-content-center mb-3">
+        <h2><%= @user.username.capitalize %>'s Pets</h2>
+      </div>
+      <div class="row row-cols-1 row-cols-md-2 g-4">
+        <% @user.own_pets.each do |pet| %>
+          <%= render "pets/pet", pet: pet %>
+        <% end %>
+      </div>
+    </div>
+  </div>
 </div>

--- a/app/views/users/failed.html.erb
+++ b/app/views/users/failed.html.erb
@@ -1,62 +1,32 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<div class="container-fluid d-flex justify-content-center align-items-center flex-column">
-  <div class="container mb-3">
-    <div class="row">
-      <div class="col-lg-3 mx-auto">
-        <h1><%= @user.username.capitalize %>'s Profile</h1>
-        <div class="card" style="max-width: 15rem;">
-          <% if @user.avatar_image.present? %>
-            <div class="card-body d-flex justify-content-center">
-              <%= image_tag @user.avatar_image, class: "card-img-top" %>
-            </div>
-          <% end %>
-          <div class="card-body p-3">
-            <p class="card-text">Member since: <%= @user.created_at.strftime("%B %d, %Y") %></p>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
 
-  <div class="container mb-3">
-    <div class="col-lg-6 mx-auto">
-      <ul class="nav nav-tabs mt-4 justify-content-center">
-        <li class="nav-item">
-          <%= link_to "Pending", user_path(@user.username), class: "nav-link" %>
-        </li>
-        <li class="nav-item">
-          <%= link_to "Completed", completed_path(@user.username), class: "nav-link" %>
-        </li>
-        <li class="nav-item">
-          <%= link_to "Failed", failed_path(@user.username), class: "nav-link" %>
-        </li>
-      </ul>
-      <div class="d-flex justify-content-center mb-3">
-        <h3><%= @user.username.capitalize %>'s Failed Tasks</h3>
-      </div>
-      <% @user.own_tasks.each do |task| %>
-        <% if task.status == "failed" %>
-          <%= render "tasks/task", task: task %>
-        <% end %>
-      <% end %>
-    </div>
-  </div>
+<%= render "profile" %>
 
-  <br>
-
-  <div class="container mb-3">
-    <div class="row">
-      <div class="col">
-        <div class="d-flex justify-content-center mb-3">
-          <h2><%= @user.username.capitalize %>'s Pets</h2>
-        </div>
-        <div class="row row-cols-1 row-cols-md-2 g-4">
-          <% @user.own_pets.each do |pet| %>
-            <%= render "pets/pet", pet: pet %>
-          <% end %>
-        </div>
-      </div>
-    </div>
-  </div>
+<div class="d-flex justify-content-center mb-3">
+  <h3><%= @user.username.capitalize %>'s Failed Tasks</h3>
 </div>
+
+<div class = "container">
+  <% @user.own_tasks.each do |task| %>
+    <% if task.status == "failed" %>
+      <%= render "tasks/task", task: task %>
+    <% end %>
+  <% end %>
+</div>
+
+<br>
+
+<div class="container mb-3">
+  <div class="row">
+    <div class="col">
+      <div class="d-flex justify-content-center mb-3">
+        <h2><%= @user.username.capitalize %>'s Pets</h2>
+      </div>
+      <div class="row row-cols-1 row-cols-md-2 g-4">
+        <% @user.own_pets.each do |pet| %>
+          <%= render "pets/pet", pet: pet %>
+        <% end %>
+      </div>
+    </div>
+  </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,62 +1,32 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<div class="container-fluid d-flex justify-content-center align-items-center flex-column">
-  <div class="container mb-3">
-    <div class="row">
-      <div class="col-lg-3 mx-auto ">
-        <h1><%= @user.username.capitalize %>'s Profile</h1>
-        <div class="card" style="max-width: 15rem;">
-          <% if @user.avatar_image.present? %>
-            <div class="card-body d-flex justify-content-center">
-              <%= image_tag @user.avatar_image, class: "card-img-top" %>
-            </div>
-          <% end %>
-          <div class="card-body p-3">
-            <p class="card-text">Member since: <%= @user.created_at.strftime("%B %d, %Y") %></p>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
 
-  <div class="container mb-3">
-    <div class="col-lg-6 mx-auto">
-      <ul class="nav nav-tabs mt-4 justify-content-center">
-        <li class="nav-item">
-          <%= link_to "Pending", user_path(@user.username), class: "nav-link" %>
-        </li>
-        <li class="nav-item">
-          <%= link_to "Completed", completed_path(@user.username), class: "nav-link" %>
-        </li>
-        <li class="nav-item">
-          <%= link_to "Failed", failed_path(@user.username), class: "nav-link" %>
-        </li>
-      </ul>
-      <div class="d-flex justify-content-center mb-3">
-        <h3><%= @user.username.capitalize %>'s Pending Tasks</h3>
-      </div>
-      <% @user.own_tasks.each do |task| %>
-        <% if task.status == "pending" %>
-          <%= render "tasks/task", task: task %>
-        <% end %>
-      <% end %>
-    </div>
-  </div>
+<%= render "profile" %>
 
-  <br>
-
-  <div class="container mb-3">
-    <div class="row">
-      <div class="col">
-        <div class="d-flex justify-content-center mb-3">
-          <h2><%= @user.username.capitalize %>'s Pets</h2>
-        </div>
-        <div class="row row-cols-1 row-cols-md-2 g-4">
-          <% @user.own_pets.each do |pet| %>
-            <%= render "pets/pet", pet: pet %>
-          <% end %>
-        </div>
-      </div>
-    </div>
-  </div>
+<div class="d-flex justify-content-center mb-3">
+  <h3><%= @user.username.capitalize %>'s Pending Tasks</h3>
 </div>
+
+<div class = "container mb-3">
+  <% @user.own_tasks.each do |task| %>
+    <% if task.status == "pending" %>
+      <%= render "tasks/task", task: task %>
+    <% end %>
+  <% end %>
+</div>
+
+<br>
+
+<div class="container mb-3">
+  <div class="row">
+    <div class="col">
+      <div class="d-flex justify-content-center mb-3">
+        <h2><%= @user.username.capitalize %>'s Pets</h2>
+      </div>
+      <div class="row row-cols-1 row-cols-md-2 g-4">
+        <% @user.own_pets.each do |pet| %>
+          <%= render "pets/pet", pet: pet %>
+        <% end %>
+      </div>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
close #11

description on my refactoring:

For my user's profile page view templates, the view files within the app/views/users named as:  '''show.html.erb, completed.html, and failed.html.erb'''  are sharing the same iteration of the bootstrap card code for the user's avatar image (which is displayed on the upper half of the profile page) followed by with navigation tabs for the user's tasks based on statuses. So this was just repeating the same lines of code for 3 those view template files and realized was that I could shorten the length of my code for those 3 view files by making a render for it instead. From that I then essentially removed the lines of codes for that avatar image card and navigation tabs, then put them in a another view file called ```_profile.html.erb``` and had render to display that file for those 3 view files of a user's profile page.

